### PR TITLE
try fix FFmpeg amf encode hang

### DIFF
--- a/res/vcpkg/ffmpeg/patch/0008-remove-amf-loop-query.patch
+++ b/res/vcpkg/ffmpeg/patch/0008-remove-amf-loop-query.patch
@@ -1,0 +1,26 @@
+From 1440f556234d135ce58a2ef38916c6a63b05870e Mon Sep 17 00:00:00 2001
+From: 21pages <sunboeasy@gmail.com>
+Date: Sat, 14 Dec 2024 21:39:44 +0800
+Subject: [PATCH] remove amf loop query
+
+Signed-off-by: 21pages <sunboeasy@gmail.com>
+---
+ libavcodec/amfenc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libavcodec/amfenc.c b/libavcodec/amfenc.c
+index f70f0109f6..a53a05b16b 100644
+--- a/libavcodec/amfenc.c
++++ b/libavcodec/amfenc.c
+@@ -886,7 +886,7 @@ int ff_amf_receive_packet(AVCodecContext *avctx, AVPacket *avpkt)
+                 av_usleep(1000);
+             }
+         }
+-    } while (block_and_wait);
++    } while (false); // already set query timeout
+ 
+     if (res_query == AMF_EOF) {
+         ret = AVERROR_EOF;
+-- 
+2.43.0.windows.1
+

--- a/res/vcpkg/ffmpeg/portfile.cmake
+++ b/res/vcpkg/ffmpeg/portfile.cmake
@@ -23,6 +23,7 @@ vcpkg_from_github(
     patch/0005-mediacodec-changing-bitrate.patch
     patch/0006-dlopen-libva.patch
     patch/0007-fix-linux-configure.patch
+    patch/0008-remove-amf-loop-query.patch
 )
 
 if(SOURCE_PATH MATCHES " ")


### PR DESCRIPTION
* Possible Causes
  * GPU API Call Hangs: This could occur, though it's less likely.
  * Infinite Loop: If `QueryOutput` always fails and `hwsurfaces_in_queue_max` is zero, the loop will continue indefinitely.
* Proposed Solution
  * A query_timeout patch has been added to FFmpeg with a value of 1000ms, which exceeds the time required to encode a single frame. This allows us to remove the loop.
* Test
  * After removing the loop, no frame encoding failures were encountered during testing. A single call to QueryOutput is sufficient, as it typically consumes about 12ms on a 2K screen.